### PR TITLE
Include PM2.5/PM10 averages in aggregations

### DIFF
--- a/ClimateChecker/src/main/java/Ontdekstation013/ClimateChecker/features/neighbourhood/NeighbourhoodService.java
+++ b/ClimateChecker/src/main/java/Ontdekstation013/ClimateChecker/features/neighbourhood/NeighbourhoodService.java
@@ -23,7 +23,7 @@ public class NeighbourhoodService {
     private final MeetJeStadService meetJeStadService;
     private final NeighbourhoodRepository neighbourhoodRepository;
 
-    private List<NeighbourhoodDto> getNeighbourhoodsAverageTemp(List<Neighbourhood> neighbourhoods, List<Measurement> measurements){
+    private List<NeighbourhoodDto> getNeighbourhoodsAverageTemp(List<Neighbourhood> neighbourhoods, List<Measurement> measurements) {
         List<NeighbourhoodDto> neighbourhoodDtos = new ArrayList<>();
 
         for (Neighbourhood neighbourhood : neighbourhoods) {
@@ -43,12 +43,21 @@ public class NeighbourhoodService {
                     .average();
 
             dto.setAvgTemp(avgTemp.isPresent() ? (float) avgTemp.getAsDouble() : Float.NaN);
+
+            OptionalDouble avgPm25 = measurementsInNeighbourhood.stream()
+                    .map(Measurement::getPm25)
+                    .filter(Objects::nonNull)
+                    .mapToDouble(Float::doubleValue)
+                    .average();
+
+            dto.setAvgPm25(avgPm25.isPresent() ? (float) avgPm25.getAsDouble() : null);
+
             neighbourhoodDtos.add(dto);
         }
         return neighbourhoodDtos;
     }
 
-    public List<NeighbourhoodDto> getNeighbourhoodsAtTime(Instant dateTime){
+    public List<NeighbourhoodDto> getNeighbourhoodsAtTime(Instant dateTime) {
         List<Neighbourhood> neighbourhoods = neighbourhoodRepository.findAll();
 
         int minuteMargin = meetJeStadService.getMinuteLimit();
@@ -101,15 +110,6 @@ public class NeighbourhoodService {
         return MeasurementLogic.splitIntoDayMeasurements(neighbourhoodMeasurements);
     }
 
-    /**
-     * Returns aggregated temperature buckets (min/max/avg) for all stations within a region.
-     *
-     * @param regionId    ID of the neighbourhood/region
-     * @param from        start of the time window (inclusive)
-     * @param to          end of the time window (inclusive)
-     * @param granularity "hour" or "day"
-     * @throws NotFoundException if no neighbourhood with the given ID exists
-     */
     public List<RegionAverageBucketResponse> getRegionAverageHistory(Long regionId, Instant from, Instant to, String granularity) {
         Neighbourhood neighbourhood = neighbourhoodRepository.findById(regionId)
                 .orElseThrow(() -> new NotFoundException("Region not found: " + regionId));

--- a/ClimateChecker/src/main/java/Ontdekstation013/ClimateChecker/features/neighbourhood/endpoint/NeighbourhoodDto.java
+++ b/ClimateChecker/src/main/java/Ontdekstation013/ClimateChecker/features/neighbourhood/endpoint/NeighbourhoodDto.java
@@ -16,4 +16,6 @@ public class NeighbourhoodDto {
     private float[][] coordinates;
     @JsonProperty("avgTemp")
     private float avgTemp;
+    @JsonProperty("avgPm25")
+    private Float avgPm25;
 }

--- a/ClimateChecker/src/main/java/Ontdekstation013/ClimateChecker/utility/MeasurementLogic.java
+++ b/ClimateChecker/src/main/java/Ontdekstation013/ClimateChecker/utility/MeasurementLogic.java
@@ -24,15 +24,9 @@ public class MeasurementLogic {
                 if (!dayMeasurements.containsKey(date)) {
                     dayMeasurements.put(date, new HashSet<>());
                 }
-
                 dayMeasurements.get(date).add(measurement);
             }
         }
-
-        // process into DayMeasurementResponses
-        //TODO make it give the ISO back
-        //the entry key is the date in yyyy-MM-dd format
-        //the response is an average over multiple days dus individual measurements are in correct times but they are grouped by day
 
         DateTimeFormatter pattern = DateTimeFormatter.ofPattern("dd-MM");
         List<DayMeasurementResponse> responseList = new ArrayList<>();
@@ -122,7 +116,8 @@ public class MeasurementLogic {
     }
 
     /**
-     * Groups measurements into time buckets (hour or day) and returns min/max/avg temperature per bucket.
+     * Groups measurements into time buckets (hour or day) and returns min/max/avg temperature
+     * and average pm25/pm10 per bucket.
      * Results are ordered by timestamp ascending.
      *
      * @param measurements source measurements (temperature nulls are skipped)
@@ -132,25 +127,37 @@ public class MeasurementLogic {
         ChronoUnit bucketUnit = "day".equalsIgnoreCase(granularity) ? ChronoUnit.DAYS : ChronoUnit.HOURS;
         DateTimeFormatter isoFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
-        LinkedHashMap<LocalDateTime, List<Float>> buckets = new LinkedHashMap<>();
+        LinkedHashMap<LocalDateTime, List<Float>> tempBuckets = new LinkedHashMap<>();
+        LinkedHashMap<LocalDateTime, List<Float>> pm25Buckets = new LinkedHashMap<>();
+        LinkedHashMap<LocalDateTime, List<Float>> pm10Buckets = new LinkedHashMap<>();
 
         measurements.stream()
-                .filter(m -> m.getTemperature() != null)
                 .sorted(Comparator.comparing(Measurement::getTimestamp))
                 .forEach(m -> {
                     LocalDateTime bucket = LocalDateTime.ofInstant(m.getTimestamp(), ZoneId.systemDefault())
                             .truncatedTo(bucketUnit);
-                    buckets.computeIfAbsent(bucket, k -> new ArrayList<>()).add(m.getTemperature());
+
+                    if (m.getTemperature() != null)
+                        tempBuckets.computeIfAbsent(bucket, k -> new ArrayList<>()).add(m.getTemperature());
+                    if (m.getPm25() != null)
+                        pm25Buckets.computeIfAbsent(bucket, k -> new ArrayList<>()).add(m.getPm25());
+                    if (m.getPm10() != null)
+                        pm10Buckets.computeIfAbsent(bucket, k -> new ArrayList<>()).add(m.getPm10());
                 });
 
         List<RegionAverageBucketResponse> result = new ArrayList<>();
-        for (Map.Entry<LocalDateTime, List<Float>> entry : buckets.entrySet()) {
+        for (Map.Entry<LocalDateTime, List<Float>> entry : tempBuckets.entrySet()) {
             List<Float> temps = entry.getValue();
+            List<Float> pm25s = pm25Buckets.getOrDefault(entry.getKey(), List.of());
+            List<Float> pm10s = pm10Buckets.getOrDefault(entry.getKey(), List.of());
+
             RegionAverageBucketResponse response = new RegionAverageBucketResponse();
             response.setTimestamp(entry.getKey().format(isoFormatter));
             response.setMin(temps.stream().min(Float::compare).orElse(Float.NaN));
             response.setMax(temps.stream().max(Float::compare).orElse(Float.NaN));
             response.setAvg((float) temps.stream().mapToDouble(Float::doubleValue).average().orElse(Double.NaN));
+            response.setPm25(pm25s.isEmpty() ? null : (float) pm25s.stream().mapToDouble(Float::doubleValue).average().orElse(Double.NaN));
+            response.setPm10(pm10s.isEmpty() ? null : (float) pm10s.stream().mapToDouble(Float::doubleValue).average().orElse(Double.NaN));
             result.add(response);
         }
         return result;

--- a/ClimateChecker/src/main/java/Ontdekstation013/ClimateChecker/utility/RegionAverageBucketResponse.java
+++ b/ClimateChecker/src/main/java/Ontdekstation013/ClimateChecker/utility/RegionAverageBucketResponse.java
@@ -24,4 +24,10 @@ public class RegionAverageBucketResponse {
 
     @JsonProperty("avg")
     private float avg;
+
+    @JsonProperty("pm25")
+    private Float pm25;
+
+    @JsonProperty("pm10")
+    private Float pm10;
 }


### PR DESCRIPTION
add pm2.5 and pm10 averaging to neighbourhood and region aggregation, neighbourhooddto now exposes avgpm25 and neighbourhoodservice computes it per neighbourhood skipping nulls, measurementlogic buckets temperature pm25 and pm10 by hour or day and returns null for pm when no samples, regionaveragebucketresponse gains pm25 and pm10 fields, also minor formatting and comment cleanup